### PR TITLE
Fix crash on install with invalid date format '2014' on a civicrm sys…

### DIFF
--- a/xml/auto_install.xml
+++ b/xml/auto_install.xml
@@ -15,7 +15,6 @@
       <table_name>civicrm_value_adresgegevens_12</table_name>
       <is_multiple>0</is_multiple>
       <collapse_adv_display>0</collapse_adv_display>
-      <created_date>2014-03-14 14:02:17</created_date>
       <is_reserved>0</is_reserved>
     </CustomGroup>
   </CustomGroups>


### PR DESCRIPTION
…tem with default localization.

A simple fix as the "created date" for a custom field group is not really required :-)