### PR TITLE
Revert part of 1502ee which breaks KAM

### DIFF
--- a/postcodenl.js
+++ b/postcodenl.js
@@ -158,13 +158,3 @@ function postcodenl_reset() {
     cj('.postcodenl_input_row').remove();
 }
 
-
-cj(function() {
-    cj.each(['show', 'hide'], function (i, ev) {
-        var el = cj.fn[ev];
-        cj.fn[ev] = function () {
-          this.trigger(ev);
-          return el.apply(this, arguments);
-        };
-      });
-});


### PR DESCRIPTION
While investigating https://github.com/aydun/uk.squiffle.kam/issues/48 I traced the problem to this extension and the fact that it seems to be replacing the jQuery `show` and `hide` functions with its own homebrew. I don't think that's a good idea. I'm also confused about why this extension is even doing so. Reading through 1502ee3a80c2de262150f25bfebaa53be488111e I don't see any use for the events being triggered by the homebrew functions. Perhaps it was WIP code that accidentally got committed?

Moral of the story: Replacing core jQuery functions is not a good idea and can cause unpredictable breakages.