### PR TITLE
pro6pp: fix SQL statement when no latitude or longitude is available

### DIFF
--- a/CRM/Postcodenl/ImportPro6pp.php
+++ b/CRM/Postcodenl/ImportPro6pp.php
@@ -23,7 +23,8 @@ class CRM_Postcodenl_ImportPro6pp {
    * @return int
    */
   public function importPro6pp() {
-    $fp = $this->getStreamToCSV('download_nl_sixpp.zip');
+    $fp = $this->getStreamToCSV('download_nl_sixpp.zip', TRUE, FALSE);
+    
     $headers = array();
 
     $lineNr = 0;
@@ -234,7 +235,8 @@ class CRM_Postcodenl_ImportPro6pp {
     $temp_file = tempnam(sys_get_temp_dir(), 'pro6pp');
 
     if ($useMeta) {
-      $json = file_get_contents($this->metaUrl . '?auth_key=' . $this->key . '&asset=' . $asset);
+      $get_url = $this->metaUrl . '?auth_key=' . $this->key . '&asset=' . $asset;
+      $json = file_get_contents($get_url);
       $meta_data = json_decode($json);
       $zipfile = $meta_data->results->download_link;
     } else {

--- a/CRM/Postcodenl/ImportPro6pp.php
+++ b/CRM/Postcodenl/ImportPro6pp.php
@@ -55,7 +55,9 @@ class CRM_Postcodenl_ImportPro6pp {
       $gemeente = $data[$headers[utf8_encode('municipality')]];
       $woonplaats = $data[$headers[utf8_encode('city')]];
       $lat = $data[$headers[utf8_encode('lat')]];
+      $latSql = $lat != '' ? $lat : 'NULL';
       $lng = $data[$headers[utf8_encode('lng')]];
+      $lngSql = $lng != '' ? $lng : 'NULL';
       $huisnummers = explode(";", $data[$headers[utf8_encode('streetnumbers')]]);
       //one records could contain multiple sets of housenummbers, seperated by 1-10;40-50;
       foreach ($huisnummers as $huisnr) {
@@ -80,7 +82,7 @@ class CRM_Postcodenl_ImportPro6pp {
           if (strlen($values)) {
             $values .= ",";
           }
-          $values .= " ('" . $postcode_cijfer . "', '" . $postcode_letter . "', '" . $start . "', '" . $eind . "', '" . $adres . "', '" . $even . "', '" . $provincie . "', '" . $gemeente . "', '" . $woonplaats . "', '" . $lat . "', '" . $lng . "')";
+          $values .= " ('" . $postcode_cijfer . "', '" . $postcode_letter . "', '" . $start . "', '" . $eind . "', '" . $adres . "', '" . $even . "', '" . $provincie . "', '" . $gemeente . "', '" . $woonplaats . "'," . $latSql . "," . $lngSql . ")";
         }
       }
       

--- a/postcodenl.php
+++ b/postcodenl.php
@@ -119,36 +119,36 @@ function postcodenl_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_navigationMenu
  */
 function postcodenl_civicrm_navigationMenu( &$params ) {
-  $maxKey = _postcodenl_getMenuKeyMax($params);
-
-  $parent =_postcodenl_get_parent_id_navigation_menu($params, 'Administer');
-
-  $parent['child'][$maxKey+1] = array (
-    'attributes' => array (
-      "label"=> ts('Import postcode from pro6pp'),
-      "name"=> ts('Import postcode from pro6pp'),
-      "url"=> "civicrm/admin/import/pro6pp",
-      "permission" => "administer CiviCRM",
-      "parentID" => $parent['attributes']['navID'],
-      "active" => 1,
-      //"navID" => $maxKey + 1,
-    ),
-    'child' => array(),
-  );
-
-  $contactParent =_postcodenl_get_parent_id_navigation_menu($params, 'Contacts');
-  $contactParent['child'][$maxKey+2] = array (
-    'attributes' => array (
-      "label"=> ts('Update addresses'),
-      "name"=> ts('Update addresses'),
-      "url"=> "civicrm/contact/updateaddresses",
-      "permission" => "administer CiviCRM",
-      "parentID" => $contactParent['attributes']['navID'],
-      "active" => 1,
-      //"navID" => $maxKey + 1,
-    ),
-    'child' => array(),
-  );
+  foreach ($params as &$menu) {
+    if (array_key_exists('attributes', $menu) && $menu['attributes']['name'] == 'Administer') {
+      $menu['child'][$maxKey+1] = array (
+        'attributes' => array (
+          "label"=> ts('Import postcode from pro6pp'),
+          "name"=> ts('Import postcode from pro6pp'),
+          "url"=> "civicrm/admin/import/pro6pp",
+          "permission" => "administer CiviCRM",
+          "parentID" => $parent['attributes']['navID'],
+          "active" => 1,
+          //"navID" => $maxKey + 1,
+        ),
+        'child' => array(),
+      );
+    }
+    if (array_key_exists('attributes', $menu) && $menu['attributes']['name'] == 'Contacts') {
+      $menu['child'][$maxKey+2] = array (
+        'attributes' => array (
+          "label"=> ts('Update addresses'),
+          "name"=> ts('Update addresses'),
+          "url"=> "civicrm/contact/updateaddresses",
+          "permission" => "administer CiviCRM",
+          "parentID" => $contactParent['attributes']['navID'],
+          "active" => 1,
+          //"navID" => $maxKey + 1,
+        ),
+        'child' => array(),
+      );
+    }
+  }
 }
 
 function _postcodenl_get_parent_id_navigation_menu(&$menu, $path, &$parent = NULL) {


### PR DESCRIPTION
The import of postal codes fails when there is no latitude or langitude because the SQL statement gets malformed.