### PR TITLE
Ensure html attributes are escaped in templates

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -18,11 +18,7 @@
   <version>1.40</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>4.4</ver>
-    <ver>4.5</ver>
-    <ver>4.6</ver>
-    <ver>4.7</ver>
-    <ver>5.7</ver>
+    <ver>5.65</ver>
   </compatibility>
   <civix>
     <namespace>CRM/Postcodenl</namespace>

--- a/templates/CRM/Postcodenl/Page/ImportPro6pp.tpl
+++ b/templates/CRM/Postcodenl/Page/ImportPro6pp.tpl
@@ -26,7 +26,7 @@
     </table>
     <div class="crm-submit-buttons">
         <span class="crm-button-type-done">
-            <input class="validate form-submit default" name="import" value="{ts}Import{/ts}" type="button" onclick="pro6pp_import();">
+            <input class="validate form-submit default" name="import" value="{ts escape='htmlattribute'}Import{/ts}" type="button" onclick="pro6pp_import();">
         </span>
     </div>
 </div>


### PR DESCRIPTION
This adds escape='htmlattribute' to all translations within tags, which ensures any special characters in the translated string
are properly escaped and don't break out of the quotes or cause other problems.

See https://github.com/civicrm/civicrm-core/pull/26792

Note: This requires CiviCRM 5.65 at minimum.