### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/api/v3/PostcodeNL/Get.php
+++ b/api/v3/PostcodeNL/Get.php
@@ -21,7 +21,7 @@
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_postcode_n_l_get($params) {
   $validParamFields = array(


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.